### PR TITLE
Add action parameter for enterprise api

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For more details, see the [Sample Project](https://github.com/douglasjunior/reac
 |onError|`function(error)`||A callback function, executed when reCAPTCHA encounters an error (usually network connectivity) and cannot continue until connectivity is restored. If you specify a function here, you are responsible for informing the user that they should retry.|
 |onClose|`function()`|| A callback function, executed when the Modal is closed.|
 |enterprise|`boolean`|`false`| (Experimental) Use the new [reCAPTCHA Enterprise API](https://cloud.google.com/recaptcha-enterprise/docs/using-features).|
-|action|`string`|| (Experimental) [Additional parameter](https://cloud.google.com/recaptcha-enterprise/docs/instrument-web-pages-with-checkbox#expandable-2) for reCAPTCHA Enterprise API|
+|action|`string`|| (Experimental) An [additional parameter](https://cloud.google.com/recaptcha-enterprise/docs/actions) for specifying the action name associated with the protected element for reCAPTCHA Enterprise API.|
 |recaptchaDomain|`string`|`www.google.com`|The host name of the reCAPTCHA valid api. [See detail](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally).|
 |gstaticDomain|`string`|`www.gstatic.com`|Customize reCAPTCHA `gstatic` host.|
 |hideBadge|`boolean`|`false`|When `size = 'invisible'`, you are allowed to hide the badge as long as you include the reCAPTCHA branding visibly in the user flow. [See detail](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed).|

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ For more details, see the [Sample Project](https://github.com/douglasjunior/reac
 |onError|`function(error)`||A callback function, executed when reCAPTCHA encounters an error (usually network connectivity) and cannot continue until connectivity is restored. If you specify a function here, you are responsible for informing the user that they should retry.|
 |onClose|`function()`|| A callback function, executed when the Modal is closed.|
 |enterprise|`boolean`|`false`| (Experimental) Use the new [reCAPTCHA Enterprise API](https://cloud.google.com/recaptcha-enterprise/docs/using-features).|
+|action|`string`|| (Experimental) [Additional parameter](https://cloud.google.com/recaptcha-enterprise/docs/instrument-web-pages-with-checkbox#expandable-2) for reCAPTCHA Enterprise API|
 |recaptchaDomain|`string`|`www.google.com`|The host name of the reCAPTCHA valid api. [See detail](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally).|
 |gstaticDomain|`string`|`www.gstatic.com`|Customize reCAPTCHA `gstatic` host.|
 |hideBadge|`boolean`|`false`|When `size = 'invisible'`, you are allowed to hide the badge as long as you include the reCAPTCHA branding visibly in the user flow. [See detail](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed).|

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export declare type RecaptchaProps = {
     recaptchaDomain?: string;
     gstaticDomain?: string;
     hideBadge?: boolean;
+    action?: string;
 };
 
 export declare type RecaptchaHandles = {

--- a/src/Recaptcha.js
+++ b/src/Recaptcha.js
@@ -79,6 +79,7 @@ const Recaptcha = forwardRef(({
     recaptchaDomain,
     gstaticDomain,
     hideBadge,
+    action,
 }, $ref,
 ) => {
     const $isClosed = useRef(true);
@@ -95,6 +96,7 @@ const Recaptcha = forwardRef(({
                 size,
                 theme,
                 lang,
+                action,
             },
             enterprise,
             recaptchaDomain,

--- a/src/get-template.js
+++ b/src/get-template.js
@@ -52,6 +52,7 @@ const getTemplate = (params, enterprise, recaptchaDomain, gstaticDomain, hideBad
             const siteKey = '{{siteKey}}';
             const theme = '{{theme}}';
             const size = '{{size}}';
+            const action = '{{action}}';
     
             let readyInterval;
             let onCloseInterval;
@@ -122,14 +123,18 @@ const getTemplate = (params, enterprise, recaptchaDomain, gstaticDomain, hideBad
             }
     
             const renderRecaptcha = () => {
-                widget = ${grecaptcha}.render('recaptcha-container', {
+                const recaptchaParams = {
                     sitekey: siteKey,
                     size,
                     theme,
                     callback: onVerify,
                     'expired-callback': onExpire,
                     'error-callback': onError,
-                });
+                }
+                if (action) {
+                    recaptchaParams.action = action;
+                }
+                widget = ${grecaptcha}.render('recaptcha-container', recaptchaParams);
                 if (onLoad) {
                     onLoad();
                 }


### PR DESCRIPTION
Added `action` additional parameter according reCAPTCHA Enterprise [example](https://cloud.google.com/recaptcha-enterprise/docs/instrument-web-pages-with-checkbox#expandable-2)

Please notice [JavaScript API reference for reCAPTCHA Enterprise](https://cloud.google.com/recaptcha-enterprise/docs/api-ref-checkbox-keys#javascript_api) has a mistake in the documentation. 
There `action` is the third parameter, but in examples and empirically, I have found out it must be provided in the second parameter as a property